### PR TITLE
revert the minimum required version of ldap3

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -10,7 +10,7 @@ ldapdomaindump is a tool which aims to solve this problem, by collecting and par
 
 The tool was designed with the following goals in mind:
 - Easy overview of all users/groups/computers/policies in the domain
-- Authentication both via username and password, as with NTLM hashes (requires ldap3 >=1.3.1)
+- Authentication both via username and password, as with NTLM hashes
 - Possibility to run the tool with an existing authenticated connection to an LDAP service, allowing for integration with relaying tools such as impackets ntlmrelayx
 
 The tool outputs several files containing an overview of objects in the domain:
@@ -25,7 +25,7 @@ As well as two grouped files:
 - *domain_computers_by_os*: Domain computers sorted by Operating System
 
 ## Dependencies and installation
-Requires [ldap3](https://github.com/cannatag/ldap3) > 2.0 and [dnspython](https://github.com/rthalley/dnspython)
+Requires [ldap3](https://github.com/cannatag/ldap3) >= 2.6.1 and [dnspython](https://github.com/rthalley/dnspython)
 
 Both can be installed with `pip install ldap3 dnspython`
 

--- a/setup.py
+++ b/setup.py
@@ -6,7 +6,7 @@ setup(name='ldapdomaindump',
       author_email='dirkjan@sanoweb.nl',
       url='https://github.com/dirkjanm/ldapdomaindump/',
       packages=['ldapdomaindump'],
-      install_requires=['dnspython', 'ldap3>=2.5,!=2.5.2,!=2.5.0,!=2.6', 'future'],
+      install_requires=['dnspython', 'ldap3>=2.6.1', 'future'],
       package_data={'ldapdomaindump': ['style.css']},
       include_package_data=True,
       scripts=['bin/ldapdomaindump', 'bin/ldd2bloodhound']


### PR DESCRIPTION
I saw you changed the minimum version of ldap3 back from 2.6.1, but I have faced with an issue using the version 2.5.1

If there is an object's DN containing trailing spaces (as the following)
```
CN=Any Group Name\ ,OU=Any Sub OU Name,OU=Any OU Name,DC=CONTOSO,DC=COM
```

LDAPDomainDump crashes (ldap3 2.5.1)
```
$ ldapdomaindump -o dump -u 'contoso.com\username' -p password 10.0.0.10
[*] Connecting to host...
[*] Binding to host
[+] Bind OK
[*] Starting domain dump
Traceback (most recent call last):
  File "/usr/local/bin/ldapdomaindump", line 3, in <module>
    ldapdomaindump.main()
  File "/usr/local/lib/python3.7/dist-packages/ldapdomaindump/__init__.py", line 944, in main
    dd.domainDump()
  File "/usr/local/lib/python3.7/dist-packages/ldapdomaindump/__init__.py", line 428, in domainDump
    rw.generateUsersByGroupReport(self)
  File "/usr/local/lib/python3.7/dist-packages/ldapdomaindump/__init__.py", line 778, in generateUsersByGroupReport
    grouped = dd.sortUsersByGroup(dd.users)
  File "/usr/local/lib/python3.7/dist-packages/ldapdomaindump/__init__.py", line 380, in sortUsersByGroup
    ugroups = [self.getGroupCnFromDn(group) for group in user.memberOf.values]
  File "/usr/local/lib/python3.7/dist-packages/ldapdomaindump/__init__.py", line 380, in <listcomp>
    ugroups = [self.getGroupCnFromDn(group) for group in user.memberOf.values]
  File "/usr/local/lib/python3.7/dist-packages/ldapdomaindump/__init__.py", line 363, in getGroupCnFromDn
    cn = self.unescapecn(dn.parse_dn(dnin)[0][1])
  File "/usr/local/lib/python3.7/dist-packages/ldap3/utils/dn.py", line 292, in parse_dn
    if not _validate_attribute_value(attribute_value):
  File "/usr/local/lib/python3.7/dist-packages/ldap3/utils/dn.py", line 208, in _validate_attribute_value
    raise LDAPInvalidDnError('invalid final character')
ldap3.core.exceptions.LDAPInvalidDnError: invalid final character
```

And everything is fine while using the version 2.6.1
```
$ ldapdomaindump -o dump -u 'contoso.com\username' -p password 10.0.0.10
[*] Connecting to host...
[*] Binding to host
[+] Bind OK
[*] Starting domain dump
[+] Domain dump finished
```

The bug has been fixed in ldap3 version 2.6.1:
https://github.com/cannatag/ldap3/commit/64cac9ac1d54404af6f75291f9fae0632471f6b6