### PR TITLE
Add docs

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,1 +1,2 @@
 include ldapdomaindump/style.css
+include LICENSE Readme.md


### PR DESCRIPTION
Ensure that the both files are part of the source tarball which is published on PyPI.

The docs, especially the license file, is a requirement for a Fedora package and other distributions. It  would save me from downloading the readme and the license file as part of the build process. Thanks

Could you please publish a release after merging?