### PR TITLE
Ensure formatString returns a string

### DIFF
--- a/ldapdomaindump/__init__.py
+++ b/ldapdomaindump/__init__.py
@@ -594,6 +594,8 @@ class reportWriter(object):
         elif isinstance(value, bytes):
             # Make sure it's a unicode string
             return_value = value.encode('utf8')
+        elif isinstance(value, list):
+            return_value = ', '.join(value)
         elif value is None:
             return_value = ''
         else:

--- a/ldapdomaindump/__init__.py
+++ b/ldapdomaindump/__init__.py
@@ -599,7 +599,7 @@ class reportWriter(object):
         if value is None:
             return ''
         #Other type: just return it
-        return value
+        return str(value)
 
     #Format an attribute to a human readable format
     def formatAttribute(self, att, formatCnAsGroup=False):

--- a/ldapdomaindump/__init__.py
+++ b/ldapdomaindump/__init__.py
@@ -583,23 +583,28 @@ class reportWriter(object):
 
     #Format a value for HTML
     def formatString(self, value):
+        return_value: str
+
         if type(value) is datetime:
             try:
-                return value.strftime('%x %X')
+                return_value = value.strftime('%x %X')
             except ValueError:
                 #Invalid date
-                return '0'
+                return_value = '0'
         # Make sure it's a unicode string
-        if type(value) is bytes:
-            return value.encode('utf8')
-        if type(value) is str:
-            return value#.encode('utf8')
-        if type(value) is int:
-            return str(value)
-        if value is None:
-            return ''
+        elif type(value) is bytes:
+            return_value = value.encode('utf8')
+        elif type(value) is str:
+            return_value = value
+        elif type(value) is int:
+            return_value = str(value)
+        elif value is None:
+            return_value = ''
+        else:
+            return_value = str(value)
+
         #Other type: just return it
-        return str(value)
+        return return_value
 
     #Format an attribute to a human readable format
     def formatAttribute(self, att, formatCnAsGroup=False):

--- a/ldapdomaindump/__init__.py
+++ b/ldapdomaindump/__init__.py
@@ -585,19 +585,15 @@ class reportWriter(object):
     def formatString(self, value):
         return_value: str
 
-        if type(value) is datetime:
+        if isinstance(value, datetime):
             try:
                 return_value = value.strftime('%x %X')
             except ValueError:
                 #Invalid date
                 return_value = '0'
-        # Make sure it's a unicode string
-        elif type(value) is bytes:
+        elif isinstance(value, bytes):
+            # Make sure it's a unicode string
             return_value = value.encode('utf8')
-        elif type(value) is str:
-            return_value = value
-        elif type(value) is int:
-            return_value = str(value)
         elif value is None:
             return_value = ''
         else:

--- a/ldapdomaindump/__init__.py
+++ b/ldapdomaindump/__init__.py
@@ -599,7 +599,6 @@ class reportWriter(object):
         else:
             return_value = str(value)
 
-        #Other type: just return it
         return return_value
 
     #Format an attribute to a human readable format


### PR DESCRIPTION
In a recent assessment, a multi-line account description was being returned as a `list`. This broke the `generateGrepList` method that was attempting to `join` the account attributes. The root of the issue appears to be that `formatString` does not guarantee that all returned values will be `str`. I refactored `formatString`:

- always return a `str` value
- use `isinstance` for type checks
- simplified the return path to a single statement
- added `formatString` handling of `list` values with a `', '.join` (this could potentially clash with `self.config.grepsplitchar`)

Copy of stack trace:
```
Traceback (most recent call last):
  File "/usr/local/bin/ldapdomaindump", line 3, in <module>
    ldapdomaindump.main()
  File "/usr/lib/python3/dist-packages/ldapdomaindump/__init__.py", line 944, in main
    dd.domainDump()
  File "/usr/lib/python3/dist-packages/ldapdomaindump/__init__.py", line 422, in domainDump
    rw.generateUsersReport(self)
  File "/usr/lib/python3/dist-packages/ldapdomaindump/__init__.py", line 797, in generateUsersReport
    grepout = self.generateGrepList(dd.users, self.userattributes)
  File "/usr/lib/python3/dist-packages/ldapdomaindump/__init__.py", line 735, in generateGrepList
    out.append(self.config.grepsplitchar.join(eo))
TypeError: sequence item 11: expected str instance, list found 
```

Redacted output data from `pdb`:
```
[snip]
    description: description line one
                 description line two
                 description line three
    displayName: Redacted User
[snip]

entry['description']
description: description line one
                 description line two
                 description line three

self.formatGrepAttribute(entry['description'])
['description line one', 'description line two', 'description line three']

[type(val) for val in eo]
[<class 'str'>, <class 'str'>, <class 'str'>, <class 'str'>, <class 'str'>, <class 'str'>, <class 'str'>, <class 'str'>, <class 'str'>, <class 'str'>, <class 'str'>, <class 'list'>]
```