### PR TITLE
Adding Kerberos Support

### DIFF
--- a/ldapdomaindump/__init__.py
+++ b/ldapdomaindump/__init__.py
@@ -48,6 +48,7 @@ uac_flags = {'ACCOUNT_DISABLED':0x00000002,
              'ACCOUNT_LOCKED':0x00000010,
              'PASSWD_NOTREQD':0x00000020,
              'PASSWD_CANT_CHANGE': 0x00000040,
+             'PASSWORD_STORE_CLEARTEXT': 0x00000080,
              'NORMAL_ACCOUNT': 0x00000200,
              'WORKSTATION_ACCOUNT':0x00001000,
              'SERVER_TRUST_ACCOUNT': 0x00002000,
@@ -81,6 +82,7 @@ trust_flags = {'NON_TRANSITIVE':0x00000001,
                'TREAT_AS_EXTERNAL':0x00000040,
                'USES_RC4_ENCRYPTION':0x00000080,
                'CROSS_ORGANIZATION_NO_TGT_DELEGATION':0x00000200,
+               'CROSS_ORGANIZATION_ENABLE_TGT_DELEGATION':0x00000800,
                'PIM_TRUST':0x00000400}
 
 # Domain trust direction
@@ -473,17 +475,17 @@ class reportWriter(object):
         if attr is None or attr.value is None:
             return outflags
         for flag, val in iteritems(flags_def):
-            if attr.value & val:
+            if int(attr.value) & val:
                 outflags.append(flag)
         return outflags
 
     #Parse bitwise trust direction - only one flag applies here, 0x03 overlaps
-    def parseTrustDirection(self, attr, flags_def):
+    def parseSingleFlag(self, attr, flags_def):
         outflags = []
         if attr is None:
             return outflags
         for flag, val in iteritems(flags_def):
-            if attr.value == val:
+            if int(attr.value) == val:
                 outflags.append(flag)
         return outflags
 
@@ -624,9 +626,9 @@ class reportWriter(object):
             if  att.value == 0:
                 return 'DISABLED'
             else:
-                return ', '.join(self.parseTrustDirection(att, trust_directions))
+                return ', '.join(self.parseSingleFlag(att, trust_directions))
         if aname == 'trusttype':
-            return ', '.join(self.parseFlags(att, trust_type))
+            return ', '.join(self.parseSingleFlag(att, trust_type))
         if aname == 'securityidentifier':
             return format_sid(att.raw_values[0])
         if aname == 'minpwdage' or  aname == 'maxpwdage':
@@ -707,9 +709,9 @@ class reportWriter(object):
             if att.value == 0:
                 return 'DISABLED'
             else:
-                return ', '.join(self.parseTrustDirection(att, trust_directions))
+                return ', '.join(self.parseSingleFlag(att, trust_directions))
         if aname == 'trusttype':
-            return ', '.join(self.parseFlags(att, trust_type))
+            return ', '.join(self.parseSingleFlag(att, trust_type))
         if aname == 'securityidentifier':
             return format_sid(att.raw_values[0])
         #Pwd flags
@@ -790,60 +792,60 @@ class reportWriter(object):
         if self.config.outputhtml:
             html = self.generateHtmlTable(dd.users, self.userattributes, 'Domain users')
             self.writeHtmlFile('%s.html' % self.config.usersfile, html)
-        if self.config.outputjson:
-            jsonout = self.generateJsonList(dd.users)
-            self.writeJsonFile('%s.json' % self.config.usersfile, jsonout)
         if self.config.outputgrep:
             grepout = self.generateGrepList(dd.users, self.userattributes)
             self.writeGrepFile('%s.grep' % self.config.usersfile, grepout)
+        if self.config.outputjson:
+            jsonout = self.generateJsonList(dd.users)
+            self.writeJsonFile('%s.json' % self.config.usersfile, jsonout)
 
     #Generate report with just a table of all computer accounts
     def generateComputersReport(self, dd):
         if self.config.outputhtml:
             html = self.generateHtmlTable(dd.computers, self.computerattributes, 'Domain computer accounts')
             self.writeHtmlFile('%s.html' % self.config.computersfile, html)
-        if self.config.outputjson:
-            jsonout = self.generateJsonList(dd.computers)
-            self.writeJsonFile('%s.json' % self.config.computersfile, jsonout)
         if self.config.outputgrep:
             grepout = self.generateGrepList(dd.computers, self.computerattributes)
             self.writeGrepFile('%s.grep' % self.config.computersfile, grepout)
+        if self.config.outputjson:
+            jsonout = self.generateJsonList(dd.computers)
+            self.writeJsonFile('%s.json' % self.config.computersfile, jsonout)
 
     #Generate report with just a table of all computer accounts
     def generateGroupsReport(self, dd):
         if self.config.outputhtml:
             html = self.generateHtmlTable(dd.groups, self.groupattributes, 'Domain groups')
             self.writeHtmlFile('%s.html' % self.config.groupsfile, html)
-        if self.config.outputjson:
-            jsonout = self.generateJsonList(dd.groups)
-            self.writeJsonFile('%s.json' % self.config.groupsfile, jsonout)
         if self.config.outputgrep:
             grepout = self.generateGrepList(dd.groups, self.groupattributes)
             self.writeGrepFile('%s.grep' % self.config.groupsfile, grepout)
+        if self.config.outputjson:
+            jsonout = self.generateJsonList(dd.groups)
+            self.writeJsonFile('%s.json' % self.config.groupsfile, jsonout)
 
     #Generate policy report
     def generatePolicyReport(self, dd):
         if self.config.outputhtml:
             html = self.generateHtmlTable(dd.policy, self.policyattributes, 'Domain policy')
             self.writeHtmlFile('%s.html' % self.config.policyfile, html)
-        if self.config.outputjson:
-            jsonout = self.generateJsonList(dd.policy)
-            self.writeJsonFile('%s.json' % self.config.policyfile, jsonout)
         if self.config.outputgrep:
             grepout = self.generateGrepList(dd.policy, self.policyattributes)
             self.writeGrepFile('%s.grep' % self.config.policyfile, grepout)
+        if self.config.outputjson:
+            jsonout = self.generateJsonList(dd.policy)
+            self.writeJsonFile('%s.json' % self.config.policyfile, jsonout)
 
     #Generate policy report
     def generateTrustsReport(self, dd):
         if self.config.outputhtml:
             html = self.generateHtmlTable(dd.trusts, self.trustattributes, 'Domain trusts')
             self.writeHtmlFile('%s.html' % self.config.trustsfile, html)
-        if self.config.outputjson:
-            jsonout = self.generateJsonList(dd.trusts)
-            self.writeJsonFile('%s.json' % self.config.trustsfile, jsonout)
         if self.config.outputgrep:
             grepout = self.generateGrepList(dd.trusts, self.trustattributes)
             self.writeGrepFile('%s.grep' % self.config.trustsfile, grepout)
+        if self.config.outputjson:
+            jsonout = self.generateJsonList(dd.trusts)
+            self.writeJsonFile('%s.json' % self.config.trustsfile, jsonout)
 
 #Some quick logging helpers
 def log_warn(text):
@@ -919,9 +921,8 @@ def main():
         else:
             authentication = NTLM
         if not '\\' in args.user:
-            #log_warn('Username must include a domain, use: DOMAIN\\username')
-            #sys.exit(1)
-             pass
+            log_warn('Username must include a domain, use: DOMAIN\\username')
+            sys.exit(1)
         if args.password is None:
             args.password = getpass.getpass()
     elif args.kerberos:

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,4 @@
 ldap3
 dnspython
 future
+gssapi


### PR DESCRIPTION
A fairly simple method of adding in Kerberos support. Very little code is added to achieve this and most of it is boiler plate to tell which type of connection we should be making. Additionally if Kerberos is selected a startTLS() call is made. Lastly gssapi was added as a requirement.

The usage of this new feature would work as follows:

1. if you dont have Kerberos support installed, install it and configure it for the environment you plan to run this.
2. obtain a ccache file using kinit or obtain one through other methods.
3. preform ldapdomaindump with the -k flag, remembering to provide a FQDN instead of an IP address.
4. Get ldapdomaindump using Kerberos.


This has been tested on kali machines. Tests were preformed using all previous methods of commands I could think of to ensure to logic was removed as well as in multiple domain setups to include ones with channel binding and signing requirements. No issues were found.