### PR TITLE
Update requirements.txt

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,3 @@
-ldap3
-dnspython
+dnspython==2.6.1
+ldap3==2.9.1
+setuptools==65.5.0


### PR DESCRIPTION
## Description

During a fresh installation, I noticed that a missing library prevented the tool from working.

I identified the missing library using `pipreqs`.

_Note that it is possible the tool also worked during my tests with the addition of the following library:_

- `pycryptodome`

Here is the error that was returned :

``` 
[🔴][Jun 27, 2024 - 15:09:14 (CEST)] exegol /workspace # ldapdomaindump --user "DOMAIN"\\"$USERNAME" --password '$PASSWORD' "ldap://$DC"
[*] Connecting to host...
[*] Binding to host
Traceback (most recent call last):
  File "/root/.local/share/pipx/venvs/ldapdomaindump/lib/python3.11/site-packages/ldap3/utils/ntlm.py", line 500, in ntowf_v2
    from Crypto.Hash import MD4  # try with the Crypto library if present
    ^^^^^^^^^^^^^^^^^^^^^^^^^^^
ModuleNotFoundError: No module named 'Crypto'

During handling of the above exception, another exception occurred:

Traceback (most recent call last):
  File "/root/.local/bin/ldapdomaindump", line 3, in <module>
    ldapdomaindump.main()
  File "/root/.local/share/pipx/venvs/ldapdomaindump/lib/python3.11/site-packages/ldapdomaindump/__init__.py", line 934, in main
    if not c.bind():
           ^^^^^^^^
  File "/root/.local/share/pipx/venvs/ldapdomaindump/lib/python3.11/site-packages/ldap3/core/connection.py", line 628, in bind
    response = self.do_ntlm_bind(controls)
               ^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/root/.local/share/pipx/venvs/ldapdomaindump/lib/python3.11/site-packages/ldap3/core/connection.py", line 1394, in do_ntlm_bind
    request = bind_operation(self.version, 'SICILY_RESPONSE_NTLM', ntlm_client,
              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/root/.local/share/pipx/venvs/ldapdomaindump/lib/python3.11/site-packages/ldap3/operation/bind.py", line 81, in bind_operation
    server_creds = name.create_authenticate_message()
                   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/root/.local/share/pipx/venvs/ldapdomaindump/lib/python3.11/site-packages/ldap3/utils/ntlm.py", line 379, in create_authenticate_message
    nt_challenge_response = self.compute_nt_response()
                            ^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/root/.local/share/pipx/venvs/ldapdomaindump/lib/python3.11/site-packages/ldap3/utils/ntlm.py", line 485, in compute_nt_response
    response_key_nt = self.ntowf_v2()
                      ^^^^^^^^^^^^^^^
  File "/root/.local/share/pipx/venvs/ldapdomaindump/lib/python3.11/site-packages/ldap3/utils/ntlm.py", line 503, in ntowf_v2
    raise e  # raise original exception
    ^^^^^^^
  File "/root/.local/share/pipx/venvs/ldapdomaindump/lib/python3.11/site-packages/ldap3/utils/ntlm.py", line 497, in ntowf_v2
    password_digest = hashlib.new('MD4', self._password.encode('utf-16-le')).digest()
                      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/root/.pyenv/versions/3.11.7/lib/python3.11/hashlib.py", line 166, in __hash_new
    return __get_builtin_constructor(name)(data)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/root/.pyenv/versions/3.11.7/lib/python3.11/hashlib.py", line 123, in __get_builtin_constructor
    raise ValueError('unsupported hash type ' + name)
ValueError: unsupported hash type MD4 ``` 
