### PR TITLE
Adding pycryptodome dependency to requirements.txt

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,3 @@
 ldap3
 dnspython
+pycryptodome


### PR DESCRIPTION
This issue was already raised in https://github.com/dirkjanm/ldapdomaindump/pull/66 but was never merged.

I got this error while running ldapdomaindump. The problem comes from ldap3 dependency. I don't know why `pycryptodome` isn't installed with this dependency. 

It has `pycryptodomex` dependency, which is the same as `pycryptodome` https://github.com/cannatag/ldap3/blob/dev/requirements.txt

- https://pypi.org/project/pycryptodome/
- https://pypi.org/project/pycryptodomex/

```
[*] Connecting to host...
[*] Binding to host
Traceback (most recent call last):
  File "/…/ldapdomaindump/venv/lib/python3.11/site-packages/ldap3/utils/ntlm.py", line 500, in ntowf_v2
    from Crypto.Hash import MD4  # try with the Crypto library if present
    ^^^^^^^^^^^^^^^^^^^^^^^^^^^
ModuleNotFoundError: No module named 'Crypto'
…
  File "/usr/lib/python3.11/hashlib.py", line 123, in __get_builtin_constructor
    raise ValueError('unsupported hash type ' + name)
ValueError: unsupported hash type MD4
```

To solve this dependency problem, I added in `requirements.txt` file : `pycryptodome`.

I'm no sure it solves the root cause of the problem. If you have a better understanding of the situation, don't hesitate to tell me and I'll try to fix it.

Best regards