### PR TITLE
LDAP simple auth option fixed

### DIFF
--- a/ldapdomaindump/__init__.py
+++ b/ldapdomaindump/__init__.py
@@ -925,13 +925,16 @@ def main():
     #Prompt for password if not set
     authentication = None
     if args.user is not None:
-        if args.authtype == 'SIMPLE':
-            authentication = 'SIMPLE'
-        else:
-            authentication = NTLM
         if not '\\' in args.user:
             log_warn('Username must include a domain, use: DOMAIN\\username')
             sys.exit(1)
+        if args.authtype == 'SIMPLE':
+            authentication = 'SIMPLE'
+            dom, usr = args.user.split('\\', 1)
+            formatted_user = f"{usr}@{dom}"
+        else:
+            authentication = NTLM
+            formatted_user = args.user
         if args.password is None:
             args.password = getpass.getpass()
     else:
@@ -940,7 +943,7 @@ def main():
     s = Server(args.host, get_info=ALL)
     log_info('Connecting to host...')
 
-    c = Connection(s, user=args.user, password=args.password, authentication=authentication)
+    c = Connection(s, user=formatted_user, password=args.password, authentication=authentication)
     log_info('Binding to host')
     # perform the Bind operation
     if not c.bind():


### PR DESCRIPTION
This MR fix the SIMPLE auth LDAP method as the username format passed to the ldap3 Connection constructor was not in the right format.
Simple auth needs either a full DN or an UPN for the username (in format username@domain). 
This fix creates the right username format according to the chosen authentication method.